### PR TITLE
Cooking skill experience fix

### DIFF
--- a/SkillPrestige.CookingSkill/ModEntry.cs
+++ b/SkillPrestige.CookingSkill/ModEntry.cs
@@ -182,13 +182,8 @@ namespace SkillPrestige.CookingSkill
         /// <param name="amount">The amount to set.</param>
         private static void SetCookingExperience(int amount)
         {
-            if (amount <= Game1.player.experiencePoints[6])
-                Game1.player.experiencePoints[6] = amount;
-            else
-            {
-                var addedExperience = amount - Game1.player.experiencePoints[6];
-                Game1.player.AddCustomSkillExperience("spacechase0.Cooking", addedExperience);
-            }
+            var addedExperience = amount - Game1.player.GetCustomSkillExperience("spacechase0.Cooking");
+            Game1.player.AddCustomSkillExperience("spacechase0.Cooking", addedExperience);
         }
     }
 }


### PR DESCRIPTION
Currently the Cooking Skill adapter uses the older method where I extended the vanilla experience array. This changes it to check through the SpaceCore skill API.