### PR TITLE
Fix prestige menu messing up order by sorting by ID.

### DIFF
--- a/SkillPrestige/Menus/PrestigeMenu.cs
+++ b/SkillPrestige/Menus/PrestigeMenu.cs
@@ -173,7 +173,7 @@ namespace SkillPrestige.Menus
             Logger.LogVerbose("Prestige menu - Initiating level 5 profession buttons...");
             var leftProfessionButtonXCenter = _leftProfessionStartingXLocation + _xSpaceAvailableForProfessionButtons / 4;
             var rightProfessionButtonXCenter = _leftProfessionStartingXLocation + (_xSpaceAvailableForProfessionButtons * .75d).Floor();
-            var firstProfession = _skill.Professions.OrderBy(x => x.Id).First(x => x is TierOneProfession);
+            var firstProfession = _skill.Professions.Where(x => x is TierOneProfession).First();
 
             _professionButtons.Add(new MinimalistProfessionButton
             {
@@ -184,7 +184,7 @@ namespace SkillPrestige.Menus
                 Selected = _prestige.PrestigeProfessionsSelected.Contains(firstProfession.Id),
                 Profession = firstProfession
             });
-            var secondProfession = _skill.Professions.OrderBy(x => x.Id).Skip(1).First(x => x is TierOneProfession);
+            var secondProfession = _skill.Professions.Where(x => x is TierOneProfession).Skip(1).First();
             _professionButtons.Add(new MinimalistProfessionButton
             {
 
@@ -202,7 +202,7 @@ namespace SkillPrestige.Menus
             Logger.LogVerbose("Prestige menu - Initiating level 10 profession buttons...");
             var buttonCenterIndex = 1;
             var canBeAfforded = _prestige.PrestigePoints >= PerSaveOptions.Instance.CostOfTierTwoPrestige;
-            foreach (var profession in _skill.Professions.OrderBy(x => x.Id).Where(x => x is TierTwoProfession)
+            foreach (var profession in _skill.Professions.Where(x => x is TierTwoProfession)
             )
             {
                 var tierTwoProfession = (TierTwoProfession)profession;


### PR DESCRIPTION
SpaceCore skills don't have them in appropriate order by ID, just by order in the professions list.

As of now, this shows up:
![StardewModdingAPI_2019-05-18_13-28-03](https://user-images.githubusercontent.com/665679/57973220-802acf80-7973-11e9-8582-eec5373bdcd3.png)
(Top row shows one profession twice, bottom are out of order.)

It should look like this (and does with this commit):
![StardewModdingAPI_2019-05-18_13-49-26](https://user-images.githubusercontent.com/665679/57973228-b0726e00-7973-11e9-8e1d-a8665ad500de.png)